### PR TITLE
Add `fatal` logging level

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,6 +9,7 @@
 - `info` for information that is good to keep track of
 - `warn` for warnings about potentially dangerous situations
 - `error` for errors that have occurred
+- `fatal` for fatal erros that have occurred
 
 ## Endpoints
 


### PR DESCRIPTION
Added a logging level for `fatal`.

I think there should be one more level after `error` that represents an error with the highest severity. I could see cases where you might want to respond differently to a fatal item vs a _somewhat_ expected error.