### PR TITLE
Accept `trace` as part of the payload

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,7 +23,7 @@ Each endpoint should accept data in the following format:
   "text": "The text you wish to be logged.",
   "trace": [{
     "file": "",
-    "line": 1
+    "line": 1,
     "method": "",
   }]
 }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,7 +79,6 @@ The `log-monster` package should be made up of three things:
 
 ### `log-monster-types`
 
-
 `log-monster-types` can be found [here](https://github.com/iwburns/log-monster-types). This library should be small and focused as well.  Here we should define the types of functions and objects that each backend should know how to deal with.
 
 ### `log-monster-backend-*`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,9 +22,9 @@ Each endpoint should accept data in the following format:
   "occurred": "2020-01-01T01:00+00:00",
   "text": "The text you wish to be logged.",
   "trace": [{
-    'file': '',
-    'line': 1
-    'method': '',
+    "file": "",
+    "line": 1
+    "method": "",
   }]
 }
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,9 +22,9 @@ Each endpoint should accept data in the following format:
   "occurred": "2020-01-01T01:00+00:00",
   "text": "The text you wish to be logged.",
   "trace": [{
-    "file": "",
+    "file": "File path and name",
     "line": 1,
-    "method": "",
+    "method": "Method called",
   }]
 }
 ```
@@ -48,6 +48,11 @@ Content-Type: application/json
   "group": "A string used to group logs together.",
   "occurred": "2020-01-01T01:00+00:00",
   "text": "The text you wish to be logged.",
+  "trace": [{
+    "file": "File path and name",
+    "line": 1,
+    "method": "Method called",
+  }]
 }
 ```
 ## Internals
@@ -91,14 +96,22 @@ export interface Entry {
   group: String,
   occurred: Date,
   text: String,
+  trace: Array<{ file: String, line: number, method: String }>,
 }
 
-export function createEntry(level: Level, group: String, occurred: Date, text: String) => Entry {
+export function createEntry(
+  level: Level,
+  group: String,
+  occurred: Date,
+  text: String,
+  trace: Array<{ file: String, line: number, method: String }>,
+) => Entry {
   return {
     level,
     group,
     occurred,
     text,
+    trace,
   };
 }
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,7 +9,6 @@
 - `info` for information that is good to keep track of
 - `warn` for warnings about potentially dangerous situations
 - `error` for errors that have occurred
-- `fatal` for fatal erros that have occurred
 
 ## Endpoints
 
@@ -22,6 +21,11 @@ Each endpoint should accept data in the following format:
   "group": "A string used to group logs together.",
   "occurred": "2020-01-01T01:00+00:00",
   "text": "The text you wish to be logged.",
+  "trace": [{
+    'file': '',
+    'line': 1
+    'method': '',
+  }]
 }
 ```
 
@@ -29,7 +33,9 @@ The `group` is just a of key to use when grouping different logs together.  Back
 
 The `occurred` is when the log occurred on the machine that is making the current request.  This is different from when that request was received by `log-monster`.  This should be in the format shown above.
 
-The `text` is just the text that will be logged using the current back-end.  
+The `text` is just the text that will be logged using the current back-end.
+
+The `trace` is an array of objects that show where something came from.
 
 Example request:
 ```


### PR DESCRIPTION
Adding a `trace` property to what the logger accepts.

I'm kinda torn on this one, honestly. I don't see it as being very useful for normal logging levels but it seems **super** important for `error` and `fatal`.

We could leave it up to the caller to append the stack trace to the `text` they send over but I think adding a separate property for it will better enable us to do something specific with the trace data, if we need to.