### PR TITLE
Adding a section for authentication

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,6 +44,7 @@ Content-Type: application/json
   "text": "The text you wish to be logged.",
 }
 ```
+
 ## Internals
 
 The `log-monster` package should be made up of three things:
@@ -107,3 +108,7 @@ export abstract class LoggingStrategy {
 ### `log-monster-backend-*`
 
 Each `log-monster-backend-*` package should export a class extending the `LoggingStrategy` class above.  Each backend is free to implement its strategy however it sees fit, optimizing for different use-cases along the way.
+
+## Authentication
+
+_tbd_


### PR DESCRIPTION
Adding a blank (for now) section for authentication. We can use this PR to flesh out what that looks like.

What about only supporting Auth0 for authentication for now? It would avoid `log-monster` from needing to have to worry about in-house auth.

I think support for different authentication providers would be ideal but outside of the initial scope of this package.